### PR TITLE
feat: org-wide default issue templates (native type + board auto-add)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,28 @@
+---
+name: 🐛 Bug Report
+about: Report a bug or unexpected behavior
+title: ""
+type: Bug
+projects: ["5"]
+assignees: ""
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. See error
+
+**Expected behavior**
+A clear description of what you expected to happen.
+
+**Environment**
+- Component: [langwatch/langwatch_nlp/langwatch_mcp_server/langwatch_sdk_python/langwatch_sdk_typescript/langwatch_sdk_go]
+- Version: [e.g. v1.2.3]
+- Browser/OS: [if applicable]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,7 +3,7 @@ name: 🐛 Bug Report
 about: Report a bug or unexpected behavior
 title: ""
 type: Bug
-projects: ["5"]
+projects: ["langwatch/5"]
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,26 @@
+---
+name: 🔧 Chore
+about: Maintenance tasks, refactoring, or technical debt
+title: ""
+type: Task
+projects: ["5"]
+assignees: ""
+---
+
+**Description**
+What maintenance task or technical work needs to be done?
+
+**Context**
+Why is this task needed? Any background or related issues?
+
+**Scope**
+What components or areas does this affect?
+- [ ] Dependencies
+- [ ] Build/CI
+- [ ] Documentation
+- [ ] Code quality
+- [ ] Infrastructure
+- [ ] Other: __________
+
+**Additional context**
+Any specific requirements or constraints?

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -3,7 +3,7 @@ name: 🔧 Chore
 about: Maintenance tasks, refactoring, or technical debt
 title: ""
 type: Task
-projects: ["5"]
+projects: ["langwatch/5"]
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://docs.langwatch.ai
+    about: Check our docs for help
+  - name: 💬 Discord Community
+    url: https://discord.gg/langwatch
+    about: Join our community for discussions

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: ✨ Feature Request
+about: Suggest a new feature or enhancement
+title: ""
+type: Feature
+projects: ["5"]
+assignees: ""
+---
+
+**Problem**
+What problem does this feature solve? Why is it needed?
+
+**Proposed solution**
+Describe the solution you'd like to see.
+
+**Alternatives considered**
+Any alternative solutions or features you've considered?
+
+**Additional context**
+Any other context or screenshots about the feature request.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,7 @@ name: ✨ Feature Request
 about: Suggest a new feature or enhancement
 title: ""
 type: Feature
-projects: ["5"]
+projects: ["langwatch/5"]
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,16 @@
+---
+name: ❓ Question
+about: Ask a question about LangWatch
+title: ""
+projects: ["5"]
+assignees: ""
+---
+
+**Question**
+What would you like to know?
+
+**Context**
+Provide any relevant context or background information.
+
+**What have you tried?**
+Describe any troubleshooting or research you've already done.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: ❓ Question
 about: Ask a question about LangWatch
 title: ""
-projects: ["5"]
+projects: ["langwatch/5"]
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,38 @@
+name: Spike
+description: Time-boxed investigation of a tool, approach, or architecture
+labels: ["spike"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this spike investigate?
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Approach
+      description: What tool/technique are we evaluating? Why this one?
+    validations:
+      required: true
+  - type: textarea
+    id: plan
+    attributes:
+      label: Spike Plan
+      description: Concrete steps to evaluate (1-2 days max)
+    validations:
+      required: true
+  - type: textarea
+    id: success-criteria
+    attributes:
+      label: Success Criteria
+      description: How do we know if it worked? Measurable outcomes.
+    validations:
+      required: true
+  - type: textarea
+    id: deliverable
+    attributes:
+      label: Deliverable
+      description: What gets updated/produced? (Default - update this issue body with results)
+      value: Update this issue body with results and recommendation.


### PR DESCRIPTION
## What

Adds shared issue templates to the org-level `.github` repo, so every repo **without its own** `ISSUE_TEMPLATE/` inherits them as GitHub default community-health files. Copied from langwatch's existing set: bug-report, feature-request, chore, question, spike, plus config.

## Why

Repos like scenario and langwatch-saas currently have no templates, so their new issues open untyped and off the shared board. Each template here sets a native issue **Type** (Bug / Feature / Task) and `projects: ["5"]`, so inheriting repos get consistent typing and automatic membership on the shared kanban (Project #5) with zero per-repo work. This is the deterministic layer that keeps the board fed, complementing the agent-side relevance audit and labeling.

## Scope / notes

- langwatch keeps its own templates and is unaffected (own templates override org defaults).
- `blank_issues_enabled: false` steers everyone through a typed template. This is a deliberate consistency choice; any repo can override with its own `config.yml` if it needs blank issues. Flagging for a human to confirm that org-wide default is desired.
- `projects: ["5"]` routes to the org board. The built-in Projects "Auto-add" workflow is still worth enabling as a catch-all for issues created outside a template (API, etc.).